### PR TITLE
fixes requests

### DIFF
--- a/fritzinfluxdb/classes/fritzbox/handler.py
+++ b/fritzinfluxdb/classes/fritzbox/handler.py
@@ -353,7 +353,7 @@ class FritzBoxLuaHandler(FritzBoxHandlerBase):
         if isinstance(additional_params, dict):
             params = {**params, **additional_params}
 
-        data_url = f"{self.url}{service_to_request.url_path})"
+        data_url = f"{self.url}{service_to_request.url_path}"
 
         try:
             response = session_handler(data_url, timeout=self.config.connect_timeout, data=params)

--- a/fritzinfluxdb/classes/fritzbox/service_handler.py
+++ b/fritzinfluxdb/classes/fritzbox/service_handler.py
@@ -154,7 +154,7 @@ class FritzBoxLuaService(FritzBoxService):
 
         super().__init__(service_data)
 
-        url_path = service_data.get("url_path")
+        url_path = service_data.get("url_path") or FritzBoxLuaURLPath.data
         if url_path == FritzBoxLuaURLPath.data:
             self.page = service_data.get("page")
 


### PR DESCRIPTION
After making theses changes, I end up with this:

```
data_url: http://192.168.2.1/webservices/homeautoswitch.lua
params: {'sid': '96ff0541fc7d7838', 'switchcmd': 'getdevicelistinfos'}
2022-09-16 17:17:25,566 - ERROR: FritzBox Lua returned: 403 : Forbidden
2022-09-16 17:17:25,566 - ERROR: FritzBox Lua returned body: None
2022-09-16 17:17:25,567 - ERROR: Unable to request FritzBox Lua service 'Home Automation', no data returned
2022-09-16 17:17:25,567 - INFO: FritzBox Lua service 'Home Automation' will be disabled.
```