### PR TITLE
feat: add connection detail parsing for devices

### DIFF
--- a/fritzinfluxdb/classes/fritzbox/services_lua.py
+++ b/fritzinfluxdb/classes/fritzbox/services_lua.py
@@ -9,7 +9,6 @@
 
 import re
 from datetime import datetime
-from xmlrpc.client import Boolean
 
 from fritzinfluxdb.common import grab
 


### PR DESCRIPTION
### What does this PR do?

This pull request adds the ability to parse connection detail values for each active network device.

Specifically it adds:
- Is part of Mesh
- Wifi frequency
- Upstream / Downstream speed

### What issues does this PR fix or reference?

#65

### Functionality Before

The above mentioned device details are not collected.

### Functionality After

The data extraction mechanism for device properties has been extended add additional information to InfluxDB.

Data that is extracted is stored in the `txt` key. Devices can have one or more property objects (usually mostly two like "Mesh" and "Speed"). The JSON snippet below shows the different variations from a `Fritz!Box 7490` on `Fritz!OS 7.29`.

```json
{
    "properties": [
        // Device is part of Mesh, i. e. Powerline or Repeater
        {
            "txt": "Mesh",
            "link": "",
            "class": "nexus text",
            "onclick": "",
            "svg": "/css/rd/icons/ic_nexus.svg"
        },
        // Connection speed for non-WiFi devices
        {
            "txt": "166 / 150 Mbit/s",
            "onclick": "",
            "icon": "",
            "link": ""
        },
        // Connection frequency and speed for WiFi devices
        {
            "txt": "2,4 GHz, 50 / 836 Mbit/s",
            "onclick": "",
            "icon": "",
            "link": ""
        },
        // Connection frequency only (edge case to be aware of, seen intermittently on Repeater device)
        {
            "onclick": "",
            "txt": "2,4 GHz",
            "icon": "",
            "link": ""
        }
    ]
}
```

Additionally this pull request also adds a new tag `name` to certain value entries, so that a value selection based on tag value is possible within Grafana 1.8.

![wifi-over-time-example](https://user-images.githubusercontent.com/2205451/197981796-982743e4-adff-4565-bb3e-b9f385134b01.jpg)
