### PR TITLE
Suppress fibre modem errors

### DIFF
--- a/fritzinfluxdb/classes/fritzbox/handler.py
+++ b/fritzinfluxdb/classes/fritzbox/handler.py
@@ -218,6 +218,9 @@ class FritzBoxHandler(FritzBoxHandlerBase):
                 if "401" in str(e):
                     log.error(f"Failed to connect to {self.name} '{self.config.hostname}' using credentials. "
                               "Check username and password!")
+                elif "820" in str(e):
+                    service_invalid_log(f"Querying action '{action.name}' will be disabled")
+                    action.available = False
                 else:
                     log.error(f"Failed to connect to {self.name} '{self.config.hostname}': {e}")
                 continue
@@ -460,7 +463,7 @@ class FritzBoxLuaHandler(FritzBoxHandlerBase):
             pass
 
         if metric_value is None:
-            log.error(f"Unable to extract '{metric_name}' form '{data}', got '{type(metric_value)}'")
+            log.debug(f"Unable to extract '{metric_name}' form '{data}', got '{type(metric_value)}'")
             return
 
         if data_type in [int, float, bool, str]:


### PR DESCRIPTION
Querying a FRITZ!Box 5530 (fibre) works, but the following error messages appear running `./fritzinfluxdb.py`:

```
ERROR: Failed to connect to FritzBox TR-069 '192.168.2.1': UPnPError:
errorCode: 820
errorDescription: Internal Error
```

This internal error is raised by the API for the unsupported `WANDSLInterfaceConfig` that is not handled properly yet.

```
ERROR: Unable to extract 'dsl_line_length' form '{'pid': 'overview', 'hide': {'rss': True, 'ssoSet': True, 'liveTv': True, 'faxSet': True, 'dectRdio': True, 'dectMail': True, 'liveImg': True}, 'time': [], 'data': {'naslink': 'usbOv', 'fritzos': {'Productname': 'FRITZ!Box 5530', 'NoPwd': False, 'ShowDefaults': False, 'expert_mode': '1', 'fb_name': '', 'nspver': '07.30', 'isLabor': False, 'twofactor_disabled': False, 'FirmwareSigned': True, 'showUpdate': True, 'isUpdateAvail': False, 'energy': '46', 'boxDate': '22:26:52 08.11.2022'}, [...]}, 'sid': '4ff94faf74687f5a'}', got '<class 'NoneType'>'
```

The "DSL Info" part cannot be found and an error is logged. Given the default configuration, I suspect this type of log message may be common. Weighing correct logging against user irritation, I suggest setting the log level to debug.

I have to admit, the better approach would probably be to match the `link_type` (here: "Other"), but I don't know the project good enough to do that. Maybe this PR also serves only as a temporary solution.
