### PR TITLE
fix systemd complains about nobody user and standard output

### DIFF
--- a/fritzinfluxdb.service
+++ b/fritzinfluxdb.service
@@ -5,12 +5,11 @@ After=network-online.target
 
 [Service]
 Type=simple
-User=nobody
-Group=nogroup
+DynamicUser=yes
 WorkingDirectory=/opt/fritzinfluxdb
 ExecStart=/opt/fritzinfluxdb/.venv/bin/python /opt/fritzinfluxdb/fritzinfluxdb.py -d
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=fritzinfluxdb
 RemainAfterExit=no
 Restart=always


### PR DESCRIPTION
fritzinfluxdb: fritzinfluxdb v1.2.1 (2023-01-26)
OS: Centos 9 Stream

I got the following warnings in the logs:
```
Feb 18 13:03:25 sun systemd[1]: /etc/systemd/system/fritzinfluxdb.service:8: Special user nobody configured, this is not safe!
Feb 18 13:03:25 sun systemd[1]: /etc/systemd/system/fritzinfluxdb.service:12: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
Feb 18 13:03:25 sun systemd[1]: /etc/systemd/system/fritzinfluxdb.service:13: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
```