### PR TITLE
Please i found to errors two my fritz!box database created by fritzinfluxdb

### DIFF
--- a/fritzinfluxdb/classes/common.py
+++ b/fritzinfluxdb/classes/common.py
@@ -102,7 +102,7 @@ class FritzMeasurement:
         if "." in value:
             # noinspection PyBroadException
             try:
-                # try to convert value to int
+                # try to convert value to float
                 return float(value)
             except Exception:
                 pass


### PR DESCRIPTION
Please i found two errors to my fritz!box database created by fritzinfluxdb
1) wrong "external_ip" address (different by the right one but it looks like the right IP is found somewhere in the table but in previous "_time"
2) wrong speeds in up/down streams of DSL speed but only if time interval to refresh is set over the Last 12H (ex. 24H)

Fritz!box 6890 LTE with Fritz!os 7.29
Thank you in advance!